### PR TITLE
Hard Reset added in OSD + Vertical sync bug correction in VDP18

### DIFF
--- a/rtl/vdp18/vdp18_hor_vert.vhd
+++ b/rtl/vdp18/vdp18_hor_vert.vhd
@@ -177,25 +177,18 @@ begin
         end if;
 
         -- Vertical sync ------------------------------------------------------
-        if is_pal_g = 1 then
-          if    cnt_vert_q = 244 then
-            vsync_n_o <= '0';
-          elsif cnt_vert_q = 247 then
-            vsync_n_o <= '1';
-          end if;
-        else
-          if    cnt_vert_q = 218 then
-            vsync_n_o <= '0';
-          elsif cnt_vert_q = 221 then
-            vsync_n_o <= '1';
-          end if;
 
-          if    cnt_vert_q = 214 then
-            vblank_q  <= true;
-          elsif cnt_vert_q = first_line_s + 14 then
-            vblank_q  <= false;
-          end if;
-        end if;
+        if    cnt_vert_q = last_line_s - 3 then
+		    vsync_n_o <= '0';
+		  elsif cnt_vert_q = last_line_s then
+		    vsync_n_o <= '1';
+		  end if;
+		  
+		  if    cnt_vert_q = last_line_s - 6  then 
+		    vblank_q  <= true;
+		  elsif cnt_vert_q = first_line_s + 14 then
+		    vblank_q  <= false;
+		  end if;
 
       end if;
     end if;


### PR DESCRIPTION
- Hard reset implemented from poseidon port (works even when DEMISTIFY_HAVE_ARM is defined)

- VDP18 sync bug is courtesy from #thelypody and was first added to Mister port in october 2024